### PR TITLE
#41 #32 Einfügen von DROP-Table-Anweisungen, Versionen von Python und…

### DIFF
--- a/Code/ETL_Process.ipynb
+++ b/Code/ETL_Process.ipynb
@@ -3,7 +3,8 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "provenance": []
+      "provenance": [],
+      "toc_visible": true
     },
     "kernelspec": {
       "name": "python3",
@@ -37,9 +38,15 @@
     {
       "cell_type": "markdown",
       "source": [
-        "*Version*: 1.0\n",
+        "*Version*: 2.0\n",
         "\n",
-        "Version Date: 28/01/2023"
+        "Version Date: 31/01/2023\n",
+        "\n",
+        "Changes: \n",
+        "\n",
+        "*   Versionsnummern der verwendeten Pakete ausgeben (Link: https://colab.research.google.com/drive/1hEBFYWiAFUNKBRinhEY43eOEqXeaHohi#scrollTo=0CiLSmoxK2EH&line=3&uniqifier=1)\n",
+        "*   Segment zjm Löschen vorhandener Tabellen in der DWH-Datenbank eingefügt, damit diese vor Ausführung des Skriptes leer ist (Link: https://colab.research.google.com/drive/1hEBFYWiAFUNKBRinhEY43eOEqXeaHohi#scrollTo=KlUM0-X_KVhk&line=1&uniqifier=1)\n",
+        "\n"
       ],
       "metadata": {
         "id": "iquEGXxL9-hV"
@@ -103,6 +110,100 @@
         "\n",
         "print(\"\\n\" + DB_DWH_PATH)"
       ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Eventuell vorhandene Tabellen in der Datawarehouse-DB löschen\n",
+        "Es muss überprüft werden, ob in der Datawarehouse-DB schon Tabellen vorhanden sind, da dieses Skript die Tabellen in der Datawarehouse-DB anlegt. Wenn Tabellen vorhanden sind, sollen ausgegeben werden, um welche Tabellen es sich handelt und die Tabellen im Anschluss gelöscht werden."
+      ],
+      "metadata": {
+        "id": "KlUM0-X_KVhk"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Datenbankverbindung zum Datawarehouse aufbauen\n",
+        "conn = sq.connect(DB_DWH_PATH) \n",
+        "if conn is not None:\n",
+        "  cursor = conn.cursor()\n",
+        "else:\n",
+        "  print(\"Verbindung fehlgeschlagen. Bitte überprüfen!\")\n",
+        "\n",
+        "# Alle Tabellennamen aus der Datenbank ziehen\n",
+        "cursor.execute(\"SELECT name FROM sqlite_master WHERE type='table';\")\n",
+        "tablelist = cursor.fetchall()\n",
+        "\n",
+        "# Tabellennamen ausgeben, wenn vorhanden\n",
+        "if tablelist == []:\n",
+        "  print(\"In der Data Warehouse Datenbank sind keine Tabellen vorhanden. Sie können mit der Ausführung des Skriptes fortfahren.\")\n",
+        "else:\n",
+        "  print(\"Folgende Tabellen sind in der Datenbank vorhanden: \")\n",
+        "  print(tablelist)\n",
+        "\n",
+        "\n",
+        "for tablename in tablelist:\n",
+        "  try:\n",
+        "    # Name der Tabelle in einen String konvertieren, damit String-Operationen durchgeführt werden können\n",
+        "    str_tablename = str(tablename)\n",
+        "    # Entfernen von \"('\" und \"',)\" - Übriggebliebene Formatierungs-Elemente aus der Liste\n",
+        "    str_tablename = str_tablename.replace(\"('\", \"\").replace(\"',)\", \"\")\n",
+        "    \n",
+        "    # Variable mit dem SQL-Statement erstellen\n",
+        "    droptable = (\"DROP TABLE \" + str_tablename + \";\")\n",
+        "    cursor.execute(droptable)\n",
+        "    print(\"Tabelle \" + str_tablename + \" wurde aus der Datenbank gelöscht.\")\n",
+        "\n",
+        "  except:\n",
+        "    print(\"In der Datenbank sind keine Tabellen vorhanden. Sie können mit der Ausführung des Skriptes fortfahren.\")\n",
+        "\n",
+        "# Tabellen in der DB überprüfen, ob richtig gelsöcht wurde\n",
+        "cursor.execute(\"SELECT name FROM sqlite_master WHERE type='table';\")\n",
+        "tablecheck = cursor.fetchall()\n",
+        "\n",
+        "# Commit und Close\n",
+        "conn.commit()\n",
+        "conn.close()"
+      ],
+      "metadata": {
+        "id": "0jBgUJwP4k5U"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Versionen der verwendeten Pakete abfragen \n",
+        "\n",
+        "Die Versionen der verwendeten Python-Installation und der Python-Pakete abfragen. "
+      ],
+      "metadata": {
+        "id": "0CiLSmoxK2EH"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Python-Version\n",
+        "print(\"Python-Version:\")\n",
+        "!python --version\n",
+        "\n",
+        "\n",
+        "# Pandas-Version\n",
+        "print(\"\\n\" + \"Pandas-Version:\")\n",
+        "print(pd.__version__)\n",
+        "\n",
+        "# sqlitee-Version\n",
+        "print(\"\\n\" + \"sqlite3-Version:\")\n",
+        "sq.sqlite_version\n"
+      ],
+      "metadata": {
+        "id": "GefZIi4qLj-n"
+      },
       "execution_count": null,
       "outputs": []
     },


### PR DESCRIPTION
… verwendeten Bibliotheken abfragen

Im Dokument wurde ein Codeblock eingefügt, welcher checkt, ob in der Datawarehouse-Datenbank schon Tabellen vorhanden sind. Wenn, werden diese gelöscht, damit das Skript die Tabellen neu und korrekt anlegt. Außerdem wurde ein Codeblock eingefügt, welcher die verwendete Python-Version abfragt und die Versionen der Python-Bibliotheken, welche verwendet wurden, auflistet.