### PR TITLE
#44 Datentyp für SNOMED CT Codes vereinheitlichen

### DIFF
--- a/Code/Setup_and_fill_Database.ipynb
+++ b/Code/Setup_and_fill_Database.ipynb
@@ -43,15 +43,16 @@
     {
       "cell_type": "markdown",
       "source": [
-        "*Version*: 3.0\n",
+        "*Version*: 3.1\n",
         "\n",
-        "Version Date: 31/01/2023\n",
+        "Version Date: 01/02/2023\n",
         "\n",
         "Changes: \n",
         "\n",
         "*   Versionsnummern der verwendeten Pakete ausgeben (Link: https://colab.research.google.com/drive/1wVuOwvYmoFLNhWFey-3isp9MP6cUChf_#scrollTo=Q5sN1oXFZ5zU&line=4&uniqifier=1)\n",
         "*   Segment zum Löschen vorhandener Tabellen in der Source-Datenbank eingefügt, damit diese vor Ausführung des Skriptes leer ist (Link: https://colab.research.google.com/drive/1wVuOwvYmoFLNhWFey-3isp9MP6cUChf_#scrollTo=Fq6StMdUYpOu&line=2&uniqifier=1)\n",
-        "*   ER-Diagramm durch aktuelle Version ersetzt (Link: )"
+        "*   ER-Diagramm durch aktuelle Version ersetzt (Link: )\n",
+        "*   SNOMED-CT Codes einheitlich als INTEGER"
       ],
       "metadata": {
         "id": "YGDatJkm5tjL"
@@ -375,7 +376,7 @@
         "                           CODE INTEGER,\n",
         "                           DESCRIPTION VARCHAR,\n",
         "                           BASE_COST FLOAT,\n",
-        "                           REASONCODE VARCHAR,\n",
+        "                           REASONCODE INTEGER,\n",
         "                           REASONDESCRIPTION VARCHAR,\n",
         "                           FOREIGN KEY (PATIENT)\n",
         "                             REFERENCES patients (Id) \n",
@@ -464,13 +465,13 @@
         "                           PATIENT VARCHAR,\n",
         "                           PAYER VARCHAR,\n",
         "                           ENCOUNTER VARCHAR,\n",
-        "                           CODE VARCHAR,\n",
+        "                           CODE INTEGER,\n",
         "                           DESCRIPTION VARCHAR,\n",
         "                           BASE_COST FLOAT,\n",
         "                           PAYER_COVERAGE FLOAT,\n",
         "                           DISPENSES INTEGER,\n",
         "                           TOTAL_COST FLOAT,\n",
-        "                           REASONCODE VARCHAR,\n",
+        "                           REASONCODE INTEGER,\n",
         "                           REASONDESCRIPTION VARCHAR,\n",
         "                           FOREIGN KEY (PATIENT)\n",
         "                             REFERENCES patients (Id) \n",


### PR DESCRIPTION
Im Colab Notebook wurde der Datentyp der betroffenen Spalten in den Tabellen "medications" und "procedures" von VARCHAR zu INTEGER geändert. Die Version des Notebooks wurde zunächst auf 3.1 gesetzt, da noch Anpassungen folgen werden in einem anderen Issue. 

Die Dokumentation der Datenbanktabellen im Wiki wurde bereits entsprechend angepasst, mit einem Hinweis zur Abweichung von der Synthea-Dokumentation. 