### PR TITLE
Indexspalten in Datenbanken definieren

### DIFF
--- a/Code/ETL_Process.ipynb
+++ b/Code/ETL_Process.ipynb
@@ -37,9 +37,9 @@
     {
       "cell_type": "markdown",
       "source": [
-        "*Version*: 3.1\n",
+        "*Version*: 3.2\n",
         "\n",
-        "Version Date: 07/02/2023\n",
+        "Version Date: 08/02/2023\n",
         "\n",
         "Changes: \n",
         "\n",
@@ -50,7 +50,7 @@
         "*  SQL Statements zum Extrahieren der benötigten Daten aus den Tabellen der Quelldatenbank ergänzt\n",
         "* Funktion zum Auslesen der Spaltennamen einer Datenbanktabelle ergänzt\n",
         "* eindeutige Indexspalte in Tabelle F_encounter_costs ergänzt\n",
-        "\n"
+        "* Ergänzung von Indizes\n"
       ],
       "metadata": {
         "id": "iquEGXxL9-hV"
@@ -652,6 +652,15 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
+      "source": [
+        "#Überprüfung der erstellten Tabellen"
+      ],
+      "metadata": {
+        "id": "EM6Mhf2gq1P5"
+      }
+    },
+    {
       "cell_type": "code",
       "metadata": {
         "id": "0RCROkRXNexD"
@@ -749,6 +758,74 @@
       ],
       "metadata": {
         "id": "FPb7eKKIrOYj"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "#Erstellung von Indizes"
+      ],
+      "metadata": {
+        "id": "e5_EnnumrA2H"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Tabelle encounters\n",
+        "dwh_cursor.execute(\"CREATE UNIQUE INDEX IF NOT EXISTS IX_F_ENCOUNTER_COSTS_Id ON F_encounter_costs (Id);\")\n",
+        "dwh_cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_F_ENCOUNTER_COSTS_ENC_Id ON F_encounter_costs (ENC_Id);\")\n",
+        "dwh_cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_F_ENCOUNTER_COSTS_PATIENT ON F_encounter_costs (PATIENT);\")\n",
+        "dwh_cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_F_ENCOUNTER_COSTS_ENC_PAYER ON F_encounter_costs (ENC_PAYER);\")\n",
+        "dwh_cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_F_ENCOUNTER_COSTS_ENC_REASON ON F_encounter_costs (ENC_REASON);\")\n",
+        "dwh_cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_F_ENCOUNTER_COSTS_PRO_CODE ON F_encounter_costs (PRO_CODE);\")\n",
+        "dwh_cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_F_ENCOUNTER_COSTS_PRO_REASON ON F_encounter_costs (PRO_REASON);\")\n",
+        "dwh_cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_F_ENCOUNTER_COSTS_MED_CODE ON F_encounter_costs (MED_CODE);\")\n",
+        "dwh_cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_F_ENCOUNTER_COSTS_MED_REASON ON F_encounter_costs (MED_REASON);\")\n",
+        "dwh_cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_F_ENCOUNTER_COSTS_CON_CODE ON F_encounter_costs (CON_CODE);\")\n",
+        "\n",
+        "# Tabelle D_patients\n",
+        "dwh_cursor.execute(\"CREATE UNIQUE INDEX IF NOT EXISTS IX_D_PATIENTS_Id ON D_patients (Id);\")\n",
+        "\n",
+        "# Tabelle D_payers\n",
+        "dwh_cursor.execute(\"CREATE UNIQUE INDEX IF NOT EXISTS IX_D_PAYERS_Id ON D_payers (Id);\")\n",
+        "\n",
+        "# Tabelle D_snomedct\n",
+        "dwh_cursor.execute(\"CREATE UNIQUE INDEX IF NOT EXISTS IX_D_SNOMEDCT_CODE ON D_snomedct (CODE);\")\n",
+        "\n",
+        "# Tabelle D_rxnorm\n",
+        "dwh_cursor.execute(\"CREATE UNIQUE INDEX IF NOT EXISTS IX_D_RXNORM_CODE ON D_rxnorm (CODE);\")"
+      ],
+      "metadata": {
+        "id": "Y1qvnrmVrA_0"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Änderungen Committen\n",
+        "target_cnx.commit()"
+      ],
+      "metadata": {
+        "id": "REy55xPurI8B"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Alle Indizes aus der DWH-Datenbank ziehen\n",
+        "dwh_cursor.execute(\"SELECT name, tbl_name FROM sqlite_master WHERE type='index';\")\n",
+        "indexlist = dwh_cursor.fetchall()\n",
+        "indexlist"
+      ],
+      "metadata": {
+        "id": "p0QNm3n5rKkb"
       },
       "execution_count": null,
       "outputs": []

--- a/Code/Setup_and_fill_Database.ipynb
+++ b/Code/Setup_and_fill_Database.ipynb
@@ -3,8 +3,7 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "provenance": [],
-      "toc_visible": true
+      "provenance": []
     },
     "kernelspec": {
       "name": "python3",
@@ -43,16 +42,17 @@
     {
       "cell_type": "markdown",
       "source": [
-        "*Version*: 3.1\n",
+        "*Version*: 3.2\n",
         "\n",
-        "Version Date: 01/02/2023\n",
+        "Version Date: 08/02/2023\n",
         "\n",
         "Changes: \n",
         "\n",
         "*   Versionsnummern der verwendeten Pakete ausgeben (Link: https://colab.research.google.com/drive/1wVuOwvYmoFLNhWFey-3isp9MP6cUChf_#scrollTo=Q5sN1oXFZ5zU&line=4&uniqifier=1)\n",
         "*   Segment zum Löschen vorhandener Tabellen in der Source-Datenbank eingefügt, damit diese vor Ausführung des Skriptes leer ist (Link: https://colab.research.google.com/drive/1wVuOwvYmoFLNhWFey-3isp9MP6cUChf_#scrollTo=Fq6StMdUYpOu&line=2&uniqifier=1)\n",
-        "*   ER-Diagramm durch aktuelle Version ersetzt (Link: )\n",
-        "*   SNOMED-CT Codes einheitlich als INTEGER"
+        "*   ER-Diagramm durch aktuelle Version ersetzt\n",
+        "*   SNOMED-CT Codes einheitlich als INTEGER\n",
+        "*   Ergänzung von Indizes\n"
       ],
       "metadata": {
         "id": "YGDatJkm5tjL"
@@ -432,7 +432,6 @@
       "cell_type": "code",
       "source": [
         "# Tabelle Conditions\n",
-        "\n",
         "sql_table[\"conditions\"] = \"\"\"CREATE TABLE IF NOT EXISTS conditions (\n",
         "                           START DATE,\n",
         "                           STOP DATE,\n",
@@ -690,6 +689,88 @@
       ],
       "metadata": {
         "id": "ialL1lNamsYg"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Erstellung von Indizes"
+      ],
+      "metadata": {
+        "id": "LuLWLOdChggi"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Tabelle patients\n",
+        "cursor.execute(\"CREATE UNIQUE INDEX IF NOT EXISTS IX_PATIENTS_Id ON patients (Id);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_PATIENTS_BIRTHDATE ON patients (BIRTHDATE);\")\n",
+        "\n",
+        "# Tabelle payer_transitions\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_PAYER_TRANSITIONS_PATIENT ON payer_transitions (PATIENT);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_PAYER_TRANSITIONS_PATIENT ON payer_transitions (PAYER);\")\n",
+        "\n",
+        "# Tabelle payers\n",
+        "cursor.execute(\"CREATE UNIQUE INDEX IF NOT EXISTS IX_PAYERS_Id ON payers (Id);\")\n",
+        "\n",
+        "# Tabelle procedures\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_PROCEDURES_ENCOUNTER ON procedures (ENCOUNTER);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_PROCEDURES_PATIENT ON procedures (PATIENT);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_PROCEDURES_CODE ON procedures (CODE);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_PROCEDURES_REASONCODE ON procedures (REASONCODE);\")\n",
+        "\n",
+        "# Tabelle encounters\n",
+        "cursor.execute(\"CREATE UNIQUE INDEX IF NOT EXISTS IX_ENCOUNTERS_Id ON encounters (Id);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_ENCOUNTERS_PATIENT ON encounters (PATIENT);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_ENCOUNTERS_ORGANIZATION ON encounters (ORGANIZATION);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_ENCOUNTERS_PROVIDER ON encounters (PROVIDER);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_ENCOUNTERS_PAYER ON encounters (PAYER);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_ENCOUNTERS_CODE ON encounters (CODE);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_ENCOUNTERS_REASONCODE ON encounters (REASONCODE);\")\n",
+        "\n",
+        "# Tabelle conditions\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_CONDITIONS_ENCOUNTER ON conditions (ENCOUNTER);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_CONDITIONS_PATIENT ON conditions (PATIENT);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_CONDITIONS_CODE ON conditions (CODE);\")\n",
+        "\n",
+        "# Tabelle medications\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_MEDICATIONS_ENCOUNTER ON medications (ENCOUNTER);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_MEDICATIONS_PATIENT ON medications (PATIENT);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_MEDICATIONS_PAYER ON medications (PAYER);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_MEDICATIONS_CODE ON medications (CODE);\")\n",
+        "cursor.execute(\"CREATE INDEX IF NOT EXISTS IX_MEDICATIONS_REASONCODE ON medications (REASONCODE);\")"
+      ],
+      "metadata": {
+        "id": "Tklm1_C9hlB3"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Änderungen \"commiten\"\n",
+        "conn.commit()"
+      ],
+      "metadata": {
+        "id": "ikgLQKGGjnC5"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Alle Tabellennamen aus der Datenbank ziehen\n",
+        "cursor.execute(\"SELECT name, tbl_name FROM sqlite_master WHERE type='index';\")\n",
+        "indexlist = cursor.fetchall()\n",
+        "indexlist"
+      ],
+      "metadata": {
+        "id": "_vWJaXjHj0Ma"
       },
       "execution_count": null,
       "outputs": []

--- a/Code/Setup_and_fill_Database.ipynb
+++ b/Code/Setup_and_fill_Database.ipynb
@@ -764,7 +764,7 @@
     {
       "cell_type": "code",
       "source": [
-        "# Alle Tabellennamen aus der Datenbank ziehen\n",
+        "# Alle Indizes aus der Datenbank ziehen\n",
         "cursor.execute(\"SELECT name, tbl_name FROM sqlite_master WHERE type='index';\")\n",
         "indexlist = cursor.fetchall()\n",
         "indexlist"


### PR DESCRIPTION
In den Skripten [Setup_and_fill_Database.ipynb](https://github.com/Fuenfgeld/DMA2023TeamA/blob/indexspalten-in-datenbanken-definieren/Code/Setup_and_fill_Database.ipynb) und [ETL_process.ipynb](https://github.com/Fuenfgeld/DMA2023TeamA/blob/indexspalten-in-datenbanken-definieren/Code/ETL_Process.ipynb) wurden Indizes ergänzt auf häufig für JOINs oder suchen verwendete Spalten.

Diese werden im Wiki noch entsprechend dokumentiert.